### PR TITLE
freetds 1.3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'freetds' %}
-{% set version = "1.3" %}
-{% set sha256 = "8f979cad4d8350906e6c3645f70471af478d08759ed93cd3a31427f0792b5f97" %}
+{% set version = "1.3.3" %}
+{% set sha256 = "dba02e7f0661ff42dc289fc41d7cde7e03089fd326f08ee28c872ac9ff4a1c84" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     # - readline  # [not win]
 
 test:
-  - requires:
+  requires:
     # To use 'conda inspect', install conda-build
     - conda-build  # [osx]
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ requirements:
     # - readline  # [not win]
 
 test:
+  - requires:
+    # To use 'conda inspect', install conda-build
+    - conda-build  # [osx]
   commands:
     - tsql -C
     - conda inspect linkages freetds  # [linux or osx]


### PR DESCRIPTION
Update freetds to 1.3.3

Version change: bump version number from 1.3 to 1.3.3
Bug Tracker: new open issues https://github.com/FreeTDS/freetds/issues
License: https://www.freetds.org/faq.html#license and https://github.com/FreeTDS/freetds/blob/master/COPYING.txt and https://github.com/FreeTDS/freetds/blob/master/COPYING_LIB.txt
Changelog: https://github.com/FreeTDS/freetds/blob/Branch-1_3/NEWS.md
Requirements: https://github.com/FreeTDS/freetds/blob/master/freetds.spec.in

The package freetds is mentioned inside the packages:
pymssql |

Actions:
- No actions

Result:
- all-succeeded