### PR TITLE
freetds 1.3.18: rebuild against libkrb5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = 'freetds' %}
+{% set name = "freetds" %}
 {% set version = "1.3.18" %}
 {% set sha256 = "1d8561d57c71991a28f4681343785c23a6a3eb54d5bcd23897d07e3825ff2d56" %}
 
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/freetds/
     - {{ pin_subpackage('freetds') }}
@@ -19,20 +19,20 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - cmake    # [win]
+    - jom      # [win]
     - libtool  # [not win]
-    - make   # [not win]
-    - cmake  # [win]
-    - jom  # [win]
-    - perl  # [win]
+    - make     # [not win]
+    - perl     # [win]
   host:
+    - libiconv {{ libiconv }}  # [osx]
+    - libkrb5 {{ krb5 }}       # [unix]
     - openssl {{ openssl }}
-    - unixodbc 2.3.11  # [unix]
-    - krb5 1.20.1  # [unix]
-    - readline 8.2  # [not win]
-    - libiconv 1.16  # [osx]
+    - readline {{ readline }}  # [not win]
+    - unixodbc {{ unixodbc }}  # [unix]
   run:
-    - krb5     # [unix]
-    - openssl # exact pin handled through openssl run_exports
+    - libkrb5  # [unix]
+    - openssl  # exact pin handled through openssl run_exports
     # Should be taken care of by run_exports
     # - unixodbc  # [unix]
     # - readline  # [not win]
@@ -44,15 +44,15 @@ test:
   commands:
     - tsql -C
     - conda inspect linkages freetds  # [linux or osx]
-    - conda inspect objects freetds  # [osx]
+    - conda inspect objects freetds   # [osx]
 
 about:
   home: https://www.freetds.org/
   license: LGPL-2.0
   license_file:
     - COPYING_LIB.txt
-  summary: FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries
-  description: FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries
+  summary: "FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries"
+  description: "FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries"
   license_family: LGPL
   doc_url: https://www.freetds.org/docs.html
   dev_url: https://github.com/FreeTDS/freetds

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - cmake    # [win]
     - jom      # [win]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8635](https://anaconda.atlassian.net/browse/PKG-8635) 
- [Upstream repository](https://github.com/FreeTDS/freetds)
- Issues:
  - https://github.com/ContinuumIO/anaconda-issues/issues/10772
  - https://github.com/conda-forge/krb5-feedstock/issues/48 

### Explanation of changes:

- Rebuild against libkrb5 1.21.3 
- Updated build number from 0 to 1
- Sort dependencies

### Notes:

- This rebuild addresses downstream dependency issues with krb5 1.21.3


[PKG-8635]: https://anaconda.atlassian.net/browse/PKG-8635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ