### PR TITLE
PKG-11944-rebuild-freetds-1.5.10-for-libkrb5-1.22.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b5aa4377a669b266ff26f2d11893e65430bef377eefd92934832310774dc6942
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/freetds/
     - {{ pin_subpackage('freetds') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 1
   run_exports:
+    # Full backward compatibility so far:
     # https://abi-laboratory.pro/tracker/timeline/freetds/
     - {{ pin_subpackage('freetds') }}
 
@@ -46,8 +47,7 @@ test:
 about:
   home: https://www.freetds.org
   license: LGPL-2.0
-  license_file:
-    - COPYING_LIB.txt
+  license_file: COPYING_LIB.txt
   summary: FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries
   description: FreeTDS is a free implementation of Sybase's DB-Library, CT-Library, and ODBC libraries
   license_family: LGPL


### PR DESCRIPTION
[PKG-11944](https://anaconda.atlassian.net/browse/PKG-11944) Rebuild for libkrb5 1.22.1

[PKG-11944]: https://anaconda.atlassian.net/browse/PKG-11944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ